### PR TITLE
Made supported

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+
+# For more information about the properties used in
+# this file, please see the EditorConfig documentation:
+# http://editorconfig.org/
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_size = 2
+indent_style = space
+
+[{.travis.yml,package.json}]
+# The indent size used in the `package.json` file cannot be changed
+# https://github.com/npm/npm/pull/3180#issuecomment-16336516
+indent_size = 2
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests            export-ignore
+/.gitattributes   export-ignore
+/.travis.yml      export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,12 @@
+inherit: true
+
+tools:
+  external_code_coverage: true
+
+checks:
+  php:
+    code_rating: true
+    duplication: true
+
+filter:
+  paths: [code/*, tests/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+# See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
+
+sudo: false
+
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+
+env:
+  - DB=MYSQL CORE_RELEASE=3.1
+
+matrix:
+  include:
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3
+    - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.1
+    - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.2
+
+before_script:
+  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+  - cd ~/builds/ss
+
+branches:
+  only:
+    - master
+
+matrix:
+  allow_failures:
+    - php: 7.0

--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@
 This module adds a "All content, page and files from across all subsites" report in the CMS, so that
 an administrator can get a quick overview of content across subsite in the site.
 
+[![Build Status](http://img.shields.io/travis/silverstripe/sitewidecontent-report.svg?style=flat-square)](https://travis-ci.org/silverstripe/sitewidecontent-report)
+[![Code Quality](http://img.shields.io/scrutinizer/g/silverstripe/sitewidecontent-report.svg?style=flat-square)](https://scrutinizer-ci.com/g/silverstripe/sitewidecontent-report)
+[![Version](http://img.shields.io/packagist/v/silverstripe/sitewidecontent-report.svg?style=flat-square)](https://packagist.org/packages/silverstripe/sitewidecontent-report)
+[![License](http://img.shields.io/packagist/l/silverstripe/sitewidecontent-report.svg?style=flat-square)](LICENSE.md)
+
 ## Install
 
-- Clone it from https://github.com/silverstripe/sitewidecontent-report.git `git clone https://github.com/silverstripe/sitewidecontent-report.git`
-- Visit your site with `?flush=1` in the url
+```sh
+$ composer require silverstripe/sitewidecontent-report
+```
+You'll then need to visit your site with `?flush=1` in the url
 
 ## Subsites Support
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.0]
+
+Changelog added.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Contributions are welcome! Create an issue, explaining a bug or proposal. Submit pull requests if you feel brave.

--- a/license.md
+++ b/license.md
@@ -1,0 +1,10 @@
+Copyright (c) 2015, Carlos Barberis
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This change bring the module's docs up to a 'supported' standard (as defined at http://www.silverstripe.org/software/addons/supported-modules-definition/)

Docs added:
- .editorconfig
- .gitattributes
- contributing.md
- license.md

Docs changed:
- .travis.yml
- README.md